### PR TITLE
fix Makefile for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	- rm *.hex
 
 $(PROJECT).o: $(PROJECT).c
-	"$(BINPATH)avr-gcc" $(CFLAGS) -I"$(INCLUDES)" $< -o $@
+	"$(BINPATH)avr-gcc" -I"$(INCLUDES)" $(CFLAGS) $< -o $@
 
 $(PROJECT).elf: $(PROJECT).o
 	"$(BINPATH)avr-gcc" $(LDFLAGS) -o $@ $< -lm


### PR DESCRIPTION
Flag sequence is changed for avr-gcc, so that it does not break on OSX. Linux will be unaffected by this.