### PR TITLE
Add ability to select LED and SPI pins configuration from Makefile

### DIFF
--- a/MYSBootloader.c
+++ b/MYSBootloader.c
@@ -64,13 +64,26 @@
 #define BOOTLOADER_COMMANDS					// Enable low level bootloader commands
 
 // SPI bus setting *****************************************************************************************************
+#if !(defined(SPI_PINS_CE9_CSN10) || defined(SPI_PINS_CSN7_CE8))
+
+#ifdef USED_MAKEFILE_SPI_PINS
+#error Invalid value for SPI_PINS Makefile variable
+#endif
+
 #define SPI_PINS_CE9_CSN10							
 //define SPI_PINS_CSN7_CE8
+#endif
 
 // LED settings ********************************************************************************************************
+#ifndef LED_DDR
 #define LED_DDR     DDRB
+#endif
+#ifndef LED_PORT
 #define LED_PORT    PORTB
+#endif
+#ifndef LED_PIN
 #define LED_PIN		PINB5
+#endif
 
 // DEBUG settings ******************************************************************************************************
 //#define DEBUG

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,21 @@ else
 	endif
 endif
 
-CFLAGS = -funsigned-char -funsigned-bitfields -DF_CPU=$(CLK) -DBAUD_RATE=$(BAUDRATE) -Os -ffunction-sections -fdata-sections -fpack-struct -fshort-enums -mrelax -Wall -Wextra -Wundef -pedantic -mmcu=$(MCU) -c -std=gnu99 -MD -MP -MF "$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$(@:%.o=%.o)" 
+ADDITIONAL_DEFINES =
+ifneq ($(strip $(LED_DDR)),)
+ADDITIONAL_DEFINES += -DLED_DDR=$(LED_DDR)
+endif
+ifneq ($(strip $(LED_PORT)),)
+ADDITIONAL_DEFINES += -DLED_PORT=$(LED_PORT)
+endif
+ifneq ($(strip $(LED_PIN)),)
+ADDITIONAL_DEFINES += -DLED_PIN=$(LED_PIN)
+endif
+ifneq ($(strip $(SPI_PINS)),)
+ADDITIONAL_DEFINES += -D$(SPI_PINS) -DUSED_MAKEFILE_SPI_PINS
+endif
+
+CFLAGS = -funsigned-char -funsigned-bitfields -DF_CPU=$(CLK) -DBAUD_RATE=$(BAUDRATE) -Os -ffunction-sections -fdata-sections -fpack-struct -fshort-enums -mrelax -Wall -Wextra -Wundef -pedantic -mmcu=$(MCU) -c -std=gnu99 -MD -MP -MF "$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -MT"$(@:%.o=%.o)" $(ADDITIONAL_DEFINES) 
 LDFLAGS = -nostartfiles -Wl,-s -Wl,-static -Wl,-Map="$(OutputFileName).map" -Wl,--start-group -Wl,--end-group -Wl,--gc-sections -mrelax -Wl,-section-start=.text=0x7800 -mmcu=$(MCU)  
 
 


### PR DESCRIPTION
Thanks to this commit I can change pin configuration without changing default values selected in code. For example:

`make LED_PIN=PINB1 SPI_PINS=SPI_PINS_CSN7_CE8`