### PR TITLE
Check in the multicompile.sh if it fits in the bootloader

### DIFF
--- a/Makefile.original
+++ b/Makefile.original
@@ -1,8 +1,8 @@
 PROJECT = MYSBootloader
 
 MCU = atmega328p
-CLK = ${frecuency}
-BAUDRATE = ${baudios}
+CLK = ${frequency}
+BAUDRATE = ${baudrate}
 
 
 ISP_PORT = com5

--- a/multicompile.sh
+++ b/multicompile.sh
@@ -1,6 +1,8 @@
 clock_speeds=( 16000000L 8000000L 1000000L )
 power_levels=( RF24_PA_MIN RF24_PA_LOW RF24_PA_HIGH RF24_PA_MAX )
 
+mkdir compiled
+
 for f in "${clock_speeds[@]}"
  do
  for i in {1..110}
@@ -27,8 +29,13 @@ for f in "${clock_speeds[@]}"
       echo "Frecuency: $f Channel: $i Baud rate: $baudios Power level: $p"
       sed -e "s/\${frecuency}/$f/" -e "s/\${baudios}/$baudios/" Makefile.original > Makefile
       make
-      mkdir compiled
-      mv MYSBootloader.hex ./compiled/MYSBootloader.ch$i.$f.$p.hex
+      if [ `avr-size -B -d MYSBootloader.elf  | tail -n 1 | awk '{print $1+$2}'` -le 2048 ]
+      then 
+	cp MYSBootloader.hex ./compiled/MYSBootloader.ch$i.$f.$p.hex
+      else
+      	echo "Compiled boot loader is too large to fit in bootloader area!!"
+      	rm --force ./compiled/MYSBootloader.ch$i.$f.$p.hex
+      fi
       
     done
   done

--- a/multicompile.sh
+++ b/multicompile.sh
@@ -13,21 +13,21 @@ for f in "${clock_speeds[@]}"
    
       if [ $f == "16000000L" ]
       then
-       baudios="115200"
+       baudrate="115200"
       fi
   
       if [ $f == "8000000L" ] 
       then
-       baudios="57600"
+       baudrate="57600"
       fi 
   
       if [ $f == "1000000L" ] 
       then
-       baudios="9600"
+       baudrate="9600"
       fi
      
-      echo "Frecuency: $f Channel: $i Baud rate: $baudios Power level: $p"
-      sed -e "s/\${frecuency}/$f/" -e "s/\${baudios}/$baudios/" Makefile.original > Makefile
+      echo "Frequency: $f Channel: $i Baud rate: $baudrate Power level: $p"
+      sed -e "s/\${frequency}/$f/" -e "s/\${baudrate}/$baudrate/" Makefile.original > Makefile
       make
       if [ `avr-size -B -d MYSBootloader.elf  | tail -n 1 | awk '{print $1+$2}'` -le 2048 ]
       then 


### PR DESCRIPTION
During a multicompile the generated hex file will only be preserved and moved to the compile directory if it fits in the bootloader area. Thus only if it is at most 2048 bytes. 
This ensures that invalid or corrupted bootloaders are being generated.