### PR TITLE
Log info of the used compiler to the compiled directory

### DIFF
--- a/multicompile.sh
+++ b/multicompile.sh
@@ -1,6 +1,24 @@
 clock_speeds=( 16000000L 8000000L 1000000L )
 power_levels=( RF24_PA_MIN RF24_PA_LOW RF24_PA_HIGH RF24_PA_MAX )
 
+mkdir compiled
+
+compiler=compiled/compiler-info.txt
+echo -e "avr-gcc version:\n================" > ${compiler}
+# avr-gcc seems to dump its specfications on stderr, so we have to redirect stderr
+avr-gcc -### 2>> ${compiler}
+echo -e "\navr-ld version:\n===============" >> ${compiler}
+avr-ld --version >> ${compiler}
+echo -e "\navr-objcopy version:\n====================" >> ${compiler}
+avr-objcopy -V >> ${compiler}
+echo -e "\navr-size version:\n=================" >> ${compiler}
+avr-size --version >> ${compiler}
+echo -e "\nCFLAGS:\n=======" >> ${compiler}
+grep "^CFLAGS" >> ${compiler} Makefile
+echo -e "\nLDFLAGS:\n========" >> ${compiler}
+grep "^LDFLAGS" >> ${compiler} Makefile
+
+
 for f in "${clock_speeds[@]}"
  do
  for i in {1..110}

--- a/multicompile.sh
+++ b/multicompile.sh
@@ -3,6 +3,22 @@ power_levels=( RF24_PA_MIN RF24_PA_LOW RF24_PA_HIGH RF24_PA_MAX )
 
 mkdir compiled
 
+compiler=compiled/compiler-info.txt
+echo -e "avr-gcc version:\n================" > ${compiler}
+# avr-gcc seems to dump its specfications on stderr, so we have to redirect stderr
+avr-gcc -### 2>> ${compiler}
+echo -e "\navr-ld version:\n===============" >> ${compiler}
+avr-ld --version >> ${compiler}
+echo -e "\navr-objcopy version:\n====================" >> ${compiler}
+avr-objcopy -V >> ${compiler}
+echo -e "\navr-size version:\n=================" >> ${compiler}
+avr-size --version >> ${compiler}
+echo -e "\nCFLAGS:\n=======" >> ${compiler}
+grep "^CFLAGS" >> ${compiler} Makefile
+echo -e "\nLDFLAGS:\n========" >> ${compiler}
+grep "^LDFLAGS" >> ${compiler} Makefile
+
+
 for f in "${clock_speeds[@]}"
  do
  for i in {1..110}


### PR DESCRIPTION
Because the compiled output is present as .hex files in the repository, it is important to know the details of the compiler that is used to compile those output files.
The multicompile.sh is extended to include the details of the used compiler in the compiler-info.txt file besides the generated .hex files.